### PR TITLE
[BLOG] correct date on py client post

### DIFF
--- a/contents/blog/python-client/index.mdx
+++ b/contents/blog/python-client/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: The Python Client -- the Foundation of OpenLineage Integrations
-date: 2022-06-27
+date: 2022-07-29
 author: Michael Robinson
 image: ./image.svg
 banner: ./banner.svg


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

The date on the Python client post is incorrect.