### PR TITLE
Adding docs link to the main homepage of openlineage

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -38,6 +38,10 @@ const siteMetadata = {
             name: "Blog",
             url: "/blog",
         },
+        {
+            name: "Docs",
+            url: "/docs"
+        },
     ],
     footerLinks: [
         {


### PR DESCRIPTION
The PR adds docs link to the top menu of the openlineage website, as /docs has many useful information for openlieage and thus need to be exposed more.

Fixes for the proposal: https://github.com/OpenLineage/OpenLineage/issues/1135

Signed-off-by: howardyoo <howardyoo@gmail.com>