### PR TITLE
[DOC] Updates the OpenLineage.yml with latest spec version.

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -9,6 +9,7 @@ LATEST_VERSION=$(find . -maxdepth 1 | grep -v 'facets' | grep '[0-9]*-[0-9]-[0-9
 echo $LATEST_VERSION
 rm ./OpenLineage.json
 ln -sf "${LATEST_VERSION}/OpenLineage.json" "."
+perl -i -pe"s/version: [[:alnum:]\.-]*/version: ${LATEST_VERSION}/g" ./OpenLineage.yml
 popd
 
 yarn run redoc-cli build --output "${APIDOC_DIR}/openapi/index.html" "${SPEC_DIR}/OpenLineage.yml" --title 'OpenLineage API Docs'


### PR DESCRIPTION
# Problem
The OpenLineage.yml has version info that is static to 0.0.1.

# Solution
The OpenLineage.yml should reflect the latest version of the spec.
fixes: #71

Signed-off-by: howardyoo <howardyoo@gmail.com>