### PR TITLE
NAN Theming Issue Resolution

### DIFF
--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -54,7 +54,7 @@ export default ({ children, front, seo, navPlaceholder=true, location }: LayoutP
     useEffect(() => {
         if(localStorage.getItem("theme")) {
             const t = Number(localStorage.getItem("theme"));
-            changeTheme(t);
+            changeTheme(t || 0);
         }
 
         if(localStorage.getItem("cookie-accept")) {


### PR DESCRIPTION
We inherited another `theme` browser storage value from our doc site hosted at the same domain that this application did not know how to handle. The doc site used a string representation while this site uses a number (0 or 1) to denote the theme. Thus this app was crashing.