### PR TITLE
[DOCS] invalid openapi html generated

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -10,7 +10,9 @@ echo $LATEST_VERSION
 rm ./OpenLineage.json 2>/dev/null
 ln -sf "${LATEST_VERSION}/OpenLineage.json" "."
 perl -i -pe"s/version: [[:alnum:]\.-]*/version: ${LATEST_VERSION:2}/g" ./OpenLineage.yml
+
+mkdir "${LATEST_VERSION}/facets"
+for i in $(ls -d ./facets/* | sort); do cp $i/*.json ${LATEST_VERSION}/facets; done;
+yarn run redoc-cli build --output "${APIDOC_DIR}/openapi/index.html" "${LATEST_VERSION}/OpenLineage.yml" --title 'OpenLineage API Docs'
+rm -rf ${LATEST_VERSION}/facets
 popd
-
-yarn run redoc-cli build --output "${APIDOC_DIR}/openapi/index.html" "${SPEC_DIR}/OpenLineage.yml" --title 'OpenLineage API Docs'
-


### PR DESCRIPTION
This PR fixes the openapi generation issue by
1. copying the latest facets into the latest version directory (under facets)
2. run the openapi generation on that latest version directory
3. removing the copied facets in facets directory.
This should ensure the redoc-cli would have the latest facets available when generating the doc.

Signed-off-by: howardyoo <howardyoo@gmail.com>

fixes #76