### PR TITLE
fixed the directory related issues when generating openapi docs.

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -15,8 +15,9 @@ for i in $(ls -d ./facets/* | sort); do cp $i/*.json ${LATEST_VERSION}/facets; d
 
 pushd $LATEST_VERSION
 ln -sf ../OpenLineage.yml .
-redoc-cli build --output "../../../${APIDOC_DIR}/openapi/index.html" "./OpenLineage.yml" --title 'OpenLineage API Docs'
+yarn run redoc-cli build --output "../../../${APIDOC_DIR}/openapi/index.html" "./OpenLineage.yml" --title 'OpenLineage API Docs'
 rm -rf facets
+rm OpenLineage.yml
 popd
 
 popd

--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -8,11 +8,15 @@ pushd $SPEC_DIR
 LATEST_VERSION=$(find . -maxdepth 1 | grep -v 'facets' | grep '[0-9]*-[0-9]-[0-9]' | sort -Vr | head -1)
 echo $LATEST_VERSION
 rm ./OpenLineage.json 2>/dev/null
-ln -sf "${LATEST_VERSION}/OpenLineage.json" "."
 perl -i -pe"s/version: [[:alnum:]\.-]*/version: ${LATEST_VERSION:2}/g" ./OpenLineage.yml
 
 mkdir "${LATEST_VERSION}/facets"
 for i in $(ls -d ./facets/* | sort); do cp $i/*.json ${LATEST_VERSION}/facets; done;
-yarn run redoc-cli build --output "${APIDOC_DIR}/openapi/index.html" "${LATEST_VERSION}/OpenLineage.yml" --title 'OpenLineage API Docs'
-rm -rf ${LATEST_VERSION}/facets
+
+pushd $LATEST_VERSION
+ln -sf ../OpenLineage.yml .
+redoc-cli build --output "../../../${APIDOC_DIR}/openapi/index.html" "./OpenLineage.yml" --title 'OpenLineage API Docs'
+rm -rf facets
+popd
+
 popd


### PR DESCRIPTION
Signed-off-by: howardyoo <howardyoo@gmail.com>
A quick fix to remedy the openapi doc generation.
1. Fixes the location issues on the facets not properly placed below latest version
2. fixes redoc cli command to output html to the proper location.