### PR TITLE
[DOC] fixed path issues with redoc-cli which was causing error

### DIFF
--- a/scripts/build-docs.sh
+++ b/scripts/build-docs.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 
-SPEC_DIR="static/spec"
-APIDOC_DIR="static/apidocs"
+SPEC_DIR="$(pwd)/static/spec"
+APIDOC_DIR="$(pwd)/static/apidocs"
 
 pushd $SPEC_DIR
 LATEST_VERSION=$(find . -maxdepth 1 | grep -v 'facets' | grep '[0-9]*-[0-9]-[0-9]' | sort -Vr | head -1)
-echo $LATEST_VERSION
+echo latest version is $LATEST_VERSION
 rm ./OpenLineage.json 2>/dev/null
 perl -i -pe"s/version: [[:alnum:]\.-]*/version: ${LATEST_VERSION:2}/g" ./OpenLineage.yml
 
@@ -15,7 +15,7 @@ for i in $(ls -d ./facets/* | sort); do cp $i/*.json ${LATEST_VERSION}/facets; d
 
 pushd $LATEST_VERSION
 ln -sf ../OpenLineage.yml .
-yarn run redoc-cli build --output "../../../${APIDOC_DIR}/openapi/index.html" "./OpenLineage.yml" --title 'OpenLineage API Docs'
+yarn run redoc-cli build --output "${APIDOC_DIR}/openapi/index.html" "${SPEC_DIR}/${LATEST_VERSION}/OpenLineage.yml" --title 'OpenLineage API Docs'
 rm -rf facets
 rm OpenLineage.yml
 popd


### PR DESCRIPTION
This fix resolves the redoc-cli error, and the remedy would be to use absolute path instead of relative paths 
for running redoc command.

Signed-off-by: howardyoo <howardyoo@gmail.com>