### PR TITLE
Enable GitHub Pages in this repo for openlineage.io

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+openlineage.io


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross.turk@astronomer.io>

DO NOT MERGE until the CNAME is removed from the `openlineage/openlineage.github.io` repository!

This pull request will enable Github Pages in this repo to serve for openlineage.io.