### PR TITLE
Roll back CI cutover until we can figure out docs fix

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-openlineage.io


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross@rossturk.com>

Applying the [openlineage.io](http://openlineage.io/) CNAME in the [openlineage.github.io](http://openlineage.github.io/) repository magically made it so that the docs repo pages deployed to [openlineage.io/docs](http://openlineage.io/docs).

However, moving that CNAME to the website repo breaks this magic. Going to roll back and research whether there is another way to get docs to ship to openlineage.io/docs.
