### PR TITLE
Publish to openlineage.github.io repo upon changes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,3 @@ jobs:
           external_repository: OpenLineage/OpenLineage.github.io
           publish_branch: gh-pages  # default: gh-pages
           publish_dir: ./public
-          cname: openlineage.io


### PR DESCRIPTION

I've added a deploy key to both repos which, along with this change, should cause the site to deploy to the `gh-pages` branch in the `openlineage.github.io` repo upon merge.

The site is currently served from `main` in that repo. Once this works, I'll update that repo to serve the site from the branch + clear out the `main` branch there except for a README explaining the purpose of the repo.
