### PR TITLE
Add CNAME for openlineage.io to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,3 +28,4 @@ jobs:
           external_repository: OpenLineage/OpenLineage.github.io
           publish_branch: gh-pages  # default: gh-pages
           publish_dir: ./public
+          cname: openlineage.io


### PR DESCRIPTION
Signed-off-by: Ross Turk <ross.turk@astronomer.io>

This will cause the deployment workflow to add a CNAME file when it publishes the site into the `openlineage.github.io` repository.