### PR TITLE
update navbar

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -41,11 +41,7 @@ const siteMetadata = {
         {
             name: "Ecosystem",
             url: "/ecosystem",
-        },
-        {
-            name: "Docs",
-            url: "/docs"
-        },
+        }
     ],
     footerLinks: [
         {


### PR DESCRIPTION
Signed-off-by: Michael Robinson <merobi@gmail.com>

Now that the new docs site is live and docs have been moved, the link to docs in the navbar should be deleted. This change removes the docs link from `config.ts`.

I noticed this because the link was returning a `404` message. Someone more familiar with Gatsby might know if anything else needs to be done.