### PR TITLE
add wiki and youtube links to home footer

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -68,7 +68,12 @@ const siteMetadata = {
             name: "Wiki",
             url: "https://bit.ly/OLwiki",
             rel: ""
-        }
+        },
+        {
+            name: "YouTube",
+            url: "https://bit.ly/OLychannel",
+            rel: ""
+        },
     ],
     social: [
         {

--- a/config.ts
+++ b/config.ts
@@ -64,6 +64,11 @@ const siteMetadata = {
             url: "https://github.com/OpenLineage/OpenLineage",
             rel: "",
         },
+        {
+            name: "Wiki",
+            url: "https://bit.ly/OLwiki",
+            rel: ""
+        }
     ],
     social: [
         {
@@ -82,7 +87,7 @@ const siteMetadata = {
             url: "#",
         },
         {
-            name: "Youtube",
+            name: "YouTube",
             icon: "/images/Youtube.svg",
             url: "#",
         },


### PR DESCRIPTION
Links to the wiki and YT channel would help users find community resources. This adds these links to the footer.