### PR TITLE
add talks to resources

### DIFF
--- a/contents/basepages/resources/index.mdx
+++ b/contents/basepages/resources/index.mdx
@@ -12,9 +12,14 @@ These resources have been gathered to help new users learn about OpenLineage, or
 
 ## Conference Talks
 
+* [Cross-platform Data Lineage with OpenLineage](https://www.youtube.com/watch?v=pLBVGIPuwEo) - Julien Le Dem @ Berlin Buzzwords (2022)
+* [Data Observability and Pipelines: OpenLineage and Marquez](https://mattturck.com/datakin/) - Matt Turck @ Data Driven NYC (2021)
+* [Data Lineage and Observability with Marquez and OpenLineage](https://bigdatatechwarsaw.eu/edition-2021/) - Julien Le Dem @ Big Data Technology Warsaw Summit (2021)
 * [Data Lineage with Apache Airflow using OpenLineage](https://airflowsummit.org/sessions/2021/data-lineage-with-apache-airflow-using-openlineage/) - Julien Le Dem & Willy Lulciuc @ Airflow Summit (2021)
 * [Observability for data pipelines with OpenLineage](https://2021.berlinbuzzwords.de/session/observability-data-pipelines-openlineage) - Julien Le Dem @ Berlin Buzzwords (2021)
 * [Data Observability and Pipelines: OpenLineage and Marquez](https://www.youtube.com/watch?v=MoW-YGjHLgI) - Julien Le Dem @ Data Driven NYC (2021)
+* [OpenLineage Lightning Talk](https://www.youtube.com/watch?v=anlV5Er_BpM) - Julien Le Dem @ MetaSpeak Metadata Day (2020)
+* [Observability for Data Pipelines: OpenLineage Project Launch](https://www.coss.community/coss/ocs-2020-breakout-julien-le-dem-3eh4) - Julien Le Dem @ Open Core Summit (2020)
 
 ## Blog Posts
 


### PR DESCRIPTION
A number of talks by Julien from 2020 and 2021 are not listed on the Resources page. This adds them to the page.