### PR TITLE
Disable cname in this repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,3 @@ jobs:
           external_repository: OpenLineage/OpenLineage.github.io
           publish_branch: gh-pages  # default: gh-pages
           publish_dir: ./public
-          cname: openlineage.io


### PR DESCRIPTION
This disables the cname for `openlineage.io` in this repo, in prep for moving to docs repo.